### PR TITLE
Change syntax highlighting language name from "lua" to "pluto"

### DIFF
--- a/docs/For Developers/Infinite Loop Prevention.md
+++ b/docs/For Developers/Infinite Loop Prevention.md
@@ -1,10 +1,10 @@
 Pluto can detect infinite loops by preventing too many successive iterations. This was implemented because game threads usually force users to call some sort of `yield` mechanism to return control to the game thread. In Pluto, you specify a hard bottleneck on iterations, then you specify a function pointer which should prevent ILP within the loop it's called in.
-```lua showLineNumbers title="This will produce an error due to ILP:"
+```pluto showLineNumbers title="This will produce an error due to ILP:"
 while true do
 
 end
 ```
-```lua showLineNumbers title="This will not, with correct configuration:"
+```pluto showLineNumbers title="This will not, with correct configuration:"
 while true do
     yield()
 end

--- a/docs/For Developers/VM Dump.md
+++ b/docs/For Developers/VM Dump.md
@@ -11,7 +11,7 @@ VM Dump can be enabled by defining `PLUTO_VMDUMP` in `luaconf.h` or your build c
 
 Given the following code:
 
-```lua showLineNumbers
+```pluto showLineNumbers
 local value = 3
 switch value do
   case 1:

--- a/docs/New Features/Break Statement.md
+++ b/docs/New Features/Break Statement.md
@@ -1,10 +1,10 @@
 This keyword accepts an optional integral argument which tells it how many levels of enclosing loops it should break. The default value is 1, thus breaking out of the current loop.
-```lua showLineNumbers title="Example 1"
+```pluto showLineNumbers title="Example 1"
 for i = 1, 10 do -- Loop 1.
     break 1 --> This is identical to `break` without any arguments.
 end
 ```
-```lua showLineNumbers title="Example 2"
+```pluto showLineNumbers title="Example 2"
 for i = 1, 10 do -- Loop 1.
     for ii = 1, 5 do -- Loop 2.
         break 1 --> This will break from Loop 2.

--- a/docs/New Features/Compiler Warnings.md
+++ b/docs/New Features/Compiler Warnings.md
@@ -12,7 +12,7 @@ These are the current warning circumstances:
 
 ## Examples
 #### Type Mismatch
-```lua showLineNumbers
+```pluto showLineNumbers
 local var: number = 5
 var = "hello"
 ```
@@ -23,7 +23,7 @@ file.lua:2: warning: 'var' was type-hinted as 'number', but is assigned a string
            |
 ```
 #### Variable Shadowing
-```lua showLineNumbers
+```pluto showLineNumbers
 local var = 5
 do
   local var = "hello"
@@ -36,7 +36,7 @@ file.lua:3: warning: duplicate local declaration
            |
 ```
 #### Unreachable Code
-```lua showLineNumbers
+```pluto showLineNumbers
 for i = 1, 10 do
   if i == 5 then
     continue
@@ -51,7 +51,7 @@ file.lua:4: warning: unreachable code
            |
 ```
 #### Excessive Arguments
-```lua showLineNumbers
+```pluto showLineNumbers
 local function func(a, b, c)
 
 end
@@ -67,7 +67,7 @@ tests/quick.lua:5: warning: too many arguments
 
 ## Compile-time Configuration
 Warnings can be disabled during compile-time, so you can make exceptions for the next line, a region of code, or the entire warning itself.
-```lua title="These are the configuration comments."
+```pluto title="These are the configuration comments."
 --- @pluto_warnings: enable-all
 --- @pluto_warnings: disable-all
 

--- a/docs/New Features/Default Arguments.md
+++ b/docs/New Features/Default Arguments.md
@@ -1,5 +1,5 @@
 During a function declaration, parameters can now declare their own default value, which must be a compile-time constant.
-```lua showLineNumbers title="Example Code"
+```pluto showLineNumbers title="Example Code"
 local function write(text = "No text provided.")
 	print(text)
 end
@@ -7,7 +7,7 @@ end
 write() 		--> "No text provided."
 write("Hello!") --> "Hello!"
 ```
-```lua showLineNumbers title="This code is semantically equal."
+```pluto showLineNumbers title="This code is semantically equal."
 local function write(text)
 	text ??= "No text provided."
 	print(text)

--- a/docs/New Features/In Expressions.md
+++ b/docs/New Features/In Expressions.md
@@ -1,5 +1,5 @@
 Searching a string for a substring, or searching an array for an element is a very simple operation now. The `in` operator has been extended to support these operations.
-```lua showLineNumbers title="Searching for a substring."
+```pluto showLineNumbers title="Searching for a substring."
 local a = "hello"
 local b = "hello world"
 
@@ -12,7 +12,7 @@ local r5 = "goodbye" in "hello world"
 assert(r1 and r2 and r3 and r4) -- They'll all return true.
 assert(r5 == false) -- Except this one.
 ```
-```lua showLineNumbers title="Searching a table for keys and elements."
+```pluto showLineNumbers title="Searching a table for keys and elements."
 local t = { [5] = "five", [6] = "six", [7] = "seven", key = "value" }
 
 assert(("key" in t) == true) -- Found a key with the value of 'key'.

--- a/docs/New Features/Numeral Parsing.md
+++ b/docs/New Features/Numeral Parsing.md
@@ -1,5 +1,5 @@
 A small change to the numeral parser allows arbitrary characters inside of numeric literals. This is applied for underscores, which will allow you to make longer numbers more readable.
-```lua showLineNumbers title="Example Code"
+```pluto showLineNumbers title="Example Code"
 local n = 10_000_000
 assert(n == 10000000)
 ```

--- a/docs/New Features/Safe Navigation.md
+++ b/docs/New Features/Safe Navigation.md
@@ -1,9 +1,9 @@
 Accessing deeply nested fields which can potentially be `nil` was problematic, because you'd need an unreasonable amount of guard clauses to prevent an "attempt to index nil" error. Pluto now offers this syntax:
-```lua showLineNumbers title="Basic Usage"
+```pluto showLineNumbers title="Basic Usage"
 local value = a?.b?.c?.d
 ```
 In this example, every field is nil. However, this does not throw an error. It simply returns `nil`. Without safe table navigation, this would've returned several "attempt to index nil" errors.
-```lua showLineNumbers title="Practical Usage"
+```pluto showLineNumbers title="Practical Usage"
 -- Pretend userConfig is parsed from a JSON file, or something.
 
 --- Returning the user's preferred color, or Red if they have no preferred color.

--- a/docs/New Features/String Indexing.md
+++ b/docs/New Features/String Indexing.md
@@ -1,5 +1,5 @@
 You can index strings for their characters now, which is cleaner & **3x** faster than using `string.sub`. String indexing only occurs when you index with an integer, either positive or negative. Positive integers index from the start of the string, and negative integers index from the end.
-```lua showLineNumbers title="Example Code"
+```pluto showLineNumbers title="Example Code"
 local str = "hello world"
 print(str[5]) -- "o"
 print(str[200]) -- nil

--- a/docs/New Features/String Interpolation.md
+++ b/docs/New Features/String Interpolation.md
@@ -1,5 +1,5 @@
 String interpolation is very simple.
-```lua
+```pluto
 local variable = "world"
 local statement = $"hello {variable}"
 

--- a/docs/New Features/Table Freezing.md
+++ b/docs/New Features/Table Freezing.md
@@ -1,6 +1,6 @@
 Tables can now be frozen at their current state to forbid any future modification. This action is irreversible and permanent for the lifespan of the table.
 
-```lua showLineNumbers title="Example Code 1"
+```pluto showLineNumbers title="Example Code 1"
 -- Disallowing any edits to the global environment table.
 table.freeze(_G)
 
@@ -9,7 +9,7 @@ _G.string = {}
 // ERROR:
 -- file.lua:2: attempt to modify frozen table.
 ```
-```lua showLineNumbers title="Example Code 2"
+```pluto showLineNumbers title="Example Code 2"
 -- Creating a constant local that's associated with a frozen table.
 local Frozen <const> = table.freeze({ 1, 2, 3 })
 
@@ -28,7 +28,7 @@ rawset(Frozen, "key", "value")
 // ERROR:
 -- file.lua:10: attempt to modify frozen table.
 ```
-```lua showLineNumbers title="Example Code 3"
+```pluto showLineNumbers title="Example Code 3"
 --- Trying to swap the value with the debug library.
 for i = 1, 249 do
   local name, value = debug.getlocal(1, i)

--- a/docs/New Features/Type Hinting.md
+++ b/docs/New Features/Type Hinting.md
@@ -1,9 +1,9 @@
 Type-hinting looks like this:
-```lua showLineNumbers
+```pluto showLineNumbers
 local var: string = "hello world"
 ```
 The parser will occasionally raise warnings when you violate the hinted type:
-```lua showLineNumbers
+```pluto showLineNumbers
 local var: string = "hello world"
 do
     var = 5
@@ -17,7 +17,7 @@ file.lua:3: warning: 'var' was type-hinted as 'string', but is assigned a number
            |
 ```
 It works with functions too:
-```lua showLineNumbers
+```pluto showLineNumbers
 local function myfunc(a: string, b: string): number
     return tonumber(a) + tonumber(b)
 end

--- a/docs/New Operators/Compound Operators.md
+++ b/docs/New Operators/Compound Operators.md
@@ -16,7 +16,7 @@ Pluto implements a plethora of compound operators, which are actually faster tha
 # Why are they faster?
 They store their left-operand in a temporary register, which reduces a lookup & makes them roughly 30% faster.
 
-```lua title="Example Code"
+```pluto title="Example Code"
 local a = 5
 
 -- Old

--- a/docs/New Operators/Null-Coalescing Operator.md
+++ b/docs/New Operators/Null-Coalescing Operator.md
@@ -1,10 +1,10 @@
 The null-coalescing operator (or more appropriately, nil-coalescing operator) is used as follows:
-```lua showLineNumbers
+```pluto showLineNumbers
 local value = nil
 local result = value ?? "This is the value if 'value' is nil."
 ```
 It's semantically equal to the following code:
-```lua showLineNumbers
+```pluto showLineNumbers
 local value = nil
 local result = if value == nil then "This is the value if 'value' is nil." else value
 ```

--- a/docs/New Operators/Walrus Operator.md
+++ b/docs/New Operators/Walrus Operator.md
@@ -1,7 +1,7 @@
 The Walrus operator allows you to perform assignment expresssions, where the second operand to your assignment is the value of the expression.
 
 ### Examples
-```lua showLineNumbers
+```pluto showLineNumbers
 if a := get_value() then
 	-- 'a' was assigned a truthy value.
 else
@@ -18,7 +18,7 @@ end
 ```
 
 Expressions for the Walrus operator may be evaluated multiple times in circumstances like loops.
-```lua showLineNumbers
+```pluto showLineNumbers
 local function get()
 	return true
 end
@@ -29,7 +29,7 @@ end
 ```
 
 Like any other expression, you can also do things like this:
-```lua showLineNumbers
+```pluto showLineNumbers
 if (a := math.random(1, 10)) < 5 then
 	print("A is less than five! Value: " .. a)
 else

--- a/docs/New Syntax/Continue Statement.md
+++ b/docs/New Syntax/Continue Statement.md
@@ -1,5 +1,5 @@
 Continue statements are meant to be used in loops, like `break`. They skip the current iteration of the loop, and they'll skip any code necessary to do so.
-```lua showLineNumbers title="Example Code"
+```pluto showLineNumbers title="Example Code"
 -- Print every number besides five.
 for i = 1, 10 do
     if i == 5 then
@@ -12,12 +12,12 @@ end
 They introduce a new keyword, `continue`. These cannot be used inside switch statements.
 ## Continue's Only Argument
 This keyword accepts an optional integral argument which tells it how many levels of enclosing loops it should skip to the end of. The default value is 1, thus skipping to the end of the current loop.
-```lua showLineNumbers title="Example 1"
+```pluto showLineNumbers title="Example 1"
 for i = 1, 10 do -- Loop 1.
     continue 1 --> This is identical to `continue` without any arguments.
 end
 ```
-```lua showLineNumbers title="Example 2"
+```pluto showLineNumbers title="Example 2"
 for i = 1, 10 do -- Loop 1.
     for ii = 1, 5 do -- Loop 2.
         continue 1 --> This will continue from Loop 2.

--- a/docs/New Syntax/Lambda Expressions.md
+++ b/docs/New Syntax/Lambda Expressions.md
@@ -1,11 +1,11 @@
 Lambda expressions are shorthand function objects for evaluating quick expressions. Take this code:
-```lua showLineNumbers title="The Old Way"
+```pluto showLineNumbers title="The Old Way"
 local s1 = "123"
 local s2 = s1:gsub(".", function (c) return tonumber(c) + 1 end)
 print(s2) -- "234"
 ```
 A lambda expression is simply syntactic sugar, because you can do this instead:
-```lua title="The New Way"
+```pluto title="The New Way"
 local s1 = "123"
 local s2 = s1:gsub(".", |c| -> tonumber(c) + 1)
 print(s2) -- "234"

--- a/docs/New Syntax/Switch Statement.md
+++ b/docs/New Syntax/Switch Statement.md
@@ -4,7 +4,7 @@ The switch statement consists of the following new keywords:
 - `default`
 
 Any variable or object can be used for the case statement, but you cannot use expressions like `1 == 1` in them.
-```lua showLineNumbers title="Example Code"
+```pluto showLineNumbers title="Example Code"
 local value = 3
 switch value do
   case 1:

--- a/docs/New Syntax/Ternary Expressions.md
+++ b/docs/New Syntax/Ternary Expressions.md
@@ -1,5 +1,5 @@
 Ternary expressions behave identical as to how they would in C. They introduce no new keywords.
-```lua showLineNumbers title="Example Code"
+```pluto showLineNumbers title="Example Code"
 -- Old
 local max
 if a > b then
@@ -12,7 +12,7 @@ end
 local max = a > b ? a : b
 ```
 They also support an alternative syntax, for compatibility with older versions of Pluto:
-```lua showLineNumbers title="Example Code"
+```pluto showLineNumbers title="Example Code"
 -- Old
 local max
 if a > b then

--- a/docs/New Syntax/When Statement.md
+++ b/docs/New Syntax/When Statement.md
@@ -1,10 +1,10 @@
 The `when` statement is vehemently similar to the `until` statement. It's simply the direct opposite.
-```lua showLineNumbers title="Looping until 'condition' is true, the old way."
+```pluto showLineNumbers title="Looping until 'condition' is true, the old way."
 repeat
     
 until not <condition>
 ```
-```lua showLineNumbers title="Looping until 'condition' is true, the new way."
+```pluto showLineNumbers title="Looping until 'condition' is true, the new way."
 repeat
 
 when <condition>

--- a/docs/QoL Improvements/Better Method Creation.md
+++ b/docs/QoL Improvements/Better Method Creation.md
@@ -1,5 +1,5 @@
 A series of methods was otherwise ugly to implement into a Lua table.
-```lua showLineNumbers title="Old Code"
+```pluto showLineNumbers title="Old Code"
 local t = {}
 
 function t:f1(...) end
@@ -7,7 +7,7 @@ function t:f2(...) end
 function t:f3(...) end
 ```
 Now, you can inline these statements inside of your table.
-```lua showLineNumbers title="New Code"
+```pluto showLineNumbers title="New Code"
 local t = {
     function f1() end,
     function f2() end,

--- a/docs/QoL Improvements/Generalized Iteration.md
+++ b/docs/QoL Improvements/Generalized Iteration.md
@@ -1,12 +1,12 @@
 It's redundant to call the `pairs` function for simple iteration. This action is now optional, and handled by the virtual machine if the function is absent.
-```lua showLineNumbers title="New Code"
+```pluto showLineNumbers title="New Code"
 local t = { 1, 2, 3, "hello", "world" }
 for key, value in t do
     print(key, value)
 end
 ```
 When you omit the function from the loop preparation, `pairs` is implicitly inserted. So, that code is identical to this:
-```lua showLineNumbers title="Old Code"
+```pluto showLineNumbers title="Old Code"
 local t = { 1, 2, 3, "hello", "world" }
 for key, value in pairs(t) do
     print(key, value)

--- a/docs/QoL Improvements/Optional Parentheses.md
+++ b/docs/QoL Improvements/Optional Parentheses.md
@@ -1,8 +1,8 @@
 The parenthesis around some types of expressions are optional now.
-```lua showLineNumbers title="Gross Way"
+```pluto showLineNumbers title="Gross Way"
 print(("hello world"):contains("world"))
 ```
-```lua showLineNumbers title="Clean Way"
+```pluto showLineNumbers title="Clean Way"
 print("hello world":contains("world"))
 ```
 In the future, this is planned to expand towards table types.

--- a/docs/QoL Improvements/Reserved Identifiers.md
+++ b/docs/QoL Improvements/Reserved Identifiers.md
@@ -1,13 +1,13 @@
 Pluto allows you to use reserved tokens such as `if` from Lua and `default` from Pluto as identifiers with shorthand table syntax and for goto labels.
 
-```lua showLineNumbers title="Reserved tokens as identifiers with shorthand table syntax"
+```pluto showLineNumbers title="Reserved tokens as identifiers with shorthand table syntax"
 local t = {
     default = "key"
 }
 print(t.default)
 ```
 
-```lua showLineNumbers title="Reserved tokens as identifiers for goto labels"
+```pluto showLineNumbers title="Reserved tokens as identifiers for goto labels"
 -- Print every number besides five.
 for i = 1, 10 do
     if i == 5 then

--- a/docs/QoL Improvements/Syntax Errors.md
+++ b/docs/QoL Improvements/Syntax Errors.md
@@ -1,20 +1,20 @@
 The messages for syntax errors are enhanced. They include tailored messages and code snippets, which should help newer programmers identify problems quicker. It's not a game changer, but it's neat.
 
 ### Example 1
-```lua showLineNumbers title="Problematic Code"
+```pluto showLineNumbers title="Problematic Code"
 if a < b and t == 5 return "Gottem" end
 ```
-```lua title="Emitted Syntax Error"
+```pluto title="Emitted Syntax Error"
 pluto: file.lua:1: syntax error: expected 'then' to delimit condition.
          1 | if a < b and t == 5 return "Gottem" end
            | ^^^^^^^^^^^^^^^^^^^^^^^^^^ here: expected 'then' symbol.
            |
 ```
 ### Example 2
-```lua showLineNumbers title="Problematic Code"
+```pluto showLineNumbers title="Problematic Code"
 local fn = |a, b, c| => (a == b and a < c)
 ```
-```lua title="Emitted Syntax Error"
+```pluto title="Emitted Syntax Error"
 pluto: file.lua:4: syntax error: impromper lambda definition
          4 | local fn = |a, b, c| => (a == b and a < c)
            | ^^^^^^^^^^^^^^^^^^^^^^ here: expected '->' arrow syntax for lambda expression.

--- a/docs/Standard Library/Base Functions.md
+++ b/docs/Standard Library/Base Functions.md
@@ -4,7 +4,7 @@ New functions for the base library, implemented by Pluto.
 #### Parameters:
 1. The amount of milliseconds to sleep for.
 #### Example
-```lua showLineNumbers title="Basic Usage"
+```pluto showLineNumbers title="Basic Usage"
 sleep(1000) --> Pause this thread for 1000ms.
 ```
 :::info

--- a/docs/Standard Library/Crypto Functions.md
+++ b/docs/Standard Library/Crypto Functions.md
@@ -5,7 +5,7 @@ Hash a string using Lua's version of the DJB2 non-cryptographic hashing algorith
 #### Parameters
 1. The string to hash.
 #### Example
-```lua showLineNumbers
+```pluto showLineNumbers
 local crypto = require("crypto")
 local str = "hello"
 assert(crypto.lua(str) == 2871868277)
@@ -15,7 +15,7 @@ Hash a string using the MD5 semi-cryptographic hashing algorithm.
 #### Parameters
 1. The string to hash.
 #### Example
-```lua showLineNumbers
+```pluto showLineNumbers
 local crypto = require("crypto")
 local str = "hello"
 assert(crypto.md5(str) == "5eb63bbbe01eeed093cb22bb8f5acdc3")
@@ -25,7 +25,7 @@ Hash a string using the DJB2 non-cryptographic hashing algorithm.
 #### Parameters
 1. The string to hash.
 #### Example
-```lua showLineNumbers
+```pluto showLineNumbers
 local crypto = require("crypto")
 local str = "hello"
 assert(crypto.djb2(str) == 894552257)
@@ -35,7 +35,7 @@ Hash a string using the FNV1 non-cryptographic hashing algorithm.
 #### Parameters
 1. The string to hash.
 #### Example
-```lua showLineNumbers
+```pluto showLineNumbers
 local crypto = require("crypto")
 local str = "hello"
 assert(crypto.fnv1(str) == 9065573210506989167)
@@ -45,7 +45,7 @@ Hash a string using the JOAAT non-cryptographic hashing algorithm.
 #### Parameters
 1. The string to hash.
 #### Example
-```lua showLineNumbers
+```pluto showLineNumbers
 local crypto = require("crypto")
 local str = "hello"
 assert(crypto.joaat(str) == 1045060183)
@@ -55,7 +55,7 @@ Hash a string using the SDBM non-cryptographic hashing algorithm.
 #### Parameters
 1. The string to hash.
 #### Example
-```lua showLineNumbers
+```pluto showLineNumbers
 local crypto = require("crypto")
 local str = "hello"
 assert(crypto.sdbm(str) == 430867652)
@@ -65,7 +65,7 @@ Hash a string using the FNV1A non-cryptographic hashing algorithm.
 #### Parameters
 1. The string to hash.
 #### Example
-```lua showLineNumbers
+```pluto showLineNumbers
 local crypto = require("crypto")
 local str = "hello"
 assert(crypto.fnv1a(str) == 8618312879776256743)
@@ -76,7 +76,7 @@ Hash a string using the CRC32 non-cryptographic hashing algorithm.
 1. The string to hash.
 2. The initial value for the hash. By default, this is zero.
 #### Example
-```lua showLineNumbers
+```pluto showLineNumbers
 local crypto = require("crypto")
 local str = "hello"
 assert(crypto.crc32(str) == 222957957)
@@ -86,7 +86,7 @@ Hash a string using the Lookup3 non-cryptographic hashing algorithm.
 #### Parameters
 1. The string to hash.
 #### Example
-```lua showLineNumbers
+```pluto showLineNumbers
 local crypto = require("crypto")
 local str = "hello"
 assert(crypto.lookup3(str) == 1252609637)
@@ -96,7 +96,7 @@ Hash a string using the Times33 non-cryptographic hashing algorithm.
 #### Parameters
 1. The string to hash.
 #### Example
-```lua showLineNumbers
+```pluto showLineNumbers
 local crypto = require("crypto")
 local str = "hello"
 assert(crypto.times33(str) == 3889643616)
@@ -106,7 +106,7 @@ Hash a string using the SHA-256 cryptographic hashing algorithm.
 #### Parameters
 1. The string to hash.
 #### Example
-```lua showLineNumbers
+```pluto showLineNumbers
 local crypto = require("crypto")
 local str = "hello"
 assert(crypto.sha256(str) == "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9")
@@ -116,7 +116,7 @@ Hash a string using the Murmur1 non-cryptographic hashing algorithm.
 #### Parameters
 1. The string to hash.
 #### Example
-```lua showLineNumbers
+```pluto showLineNumbers
 local crypto = require("crypto")
 local str = "hello"
 assert(crypto.murmur1(str) == 3154674178)
@@ -126,7 +126,7 @@ Hash a string using the Murmur2 non-cryptographic hashing algorithm.
 #### Parameters
 1. The string to hash.
 #### Example
-```lua showLineNumbers
+```pluto showLineNumbers
 local crypto = require("crypto")
 local str = "hello"
 assert(crypto.murmur2(str) == 1151865881)
@@ -136,7 +136,7 @@ Hash a string using the Murmur2A non-cryptographic hashing algorithm.
 #### Parameters
 1. The string to hash.
 #### Example
-```lua showLineNumbers
+```pluto showLineNumbers
 local crypto = require("crypto")
 local str = "hello"
 assert(crypto.murmur2a(str) == 2650573207)
@@ -146,7 +146,7 @@ Hash a string using the Murmur64A non-cryptographic hashing algorithm.
 #### Parameters
 1. The string to hash.
 #### Example
-```lua showLineNumbers
+```pluto showLineNumbers
 local crypto = require("crypto")
 local str = "hello"
 assert(crypto.murmur64a(str) == -3190198453633110066)
@@ -156,7 +156,7 @@ Hash a string using the Murmur64A non-cryptographic hashing algorithm.
 #### Parameters
 1. The string to hash.
 #### Example
-```lua showLineNumbers
+```pluto showLineNumbers
 local crypto = require("crypto")
 local str = "hello"
 assert(crypto.murmur64b(str) == 7088720765356542432)
@@ -166,7 +166,7 @@ Hash a string using the Murmur2Neutral non-cryptographic hashing algorithm.
 #### Parameters
 1. The string to hash.
 #### Example
-```lua showLineNumbers
+```pluto showLineNumbers
 local crypto = require("crypto")
 local str = "hello"
 assert(crypto.murmur2neutral(str) == 1151865881)
@@ -182,7 +182,7 @@ This is a cryptographically-secure PRNG when your system can provide those servi
 1. The minimum value to return.
 2. The maximum value to return, as a range.
 #### Example
-```lua showLineNumbers
+```pluto showLineNumbers
 local crypto = require("crypto")
 assert(crypto.random(1, 10) < 11)
 ```
@@ -193,7 +193,7 @@ Converts an integer into its hexadecimal representation, as a string.
 #### Parameters
 1. The string to convert.
 #### Example
-```lua
+```pluto
 local crypto = require("crypto")
 local hash = crypto.joaat("hello world")
 print("hash: " .. hash)

--- a/docs/Standard Library/IO Functions.md
+++ b/docs/Standard Library/IO Functions.md
@@ -5,7 +5,7 @@ New functions for the `io` library, implemented by Pluto.
 #### Returns
 A boolean indicating if the path led toward a directory.
 #### Example
-```lua showLineNumbers title="Example Usage"
+```pluto showLineNumbers title="Example Usage"
 local path = "./dir/main/"
 local bool = io.isdir(path)
 if bool then
@@ -20,7 +20,7 @@ end
 #### Returns
 A boolean indicating if the path led towards a file.
 #### Example
-```lua showLineNumbers title="Example Usage"
+```pluto showLineNumbers title="Example Usage"
 local path = "./isfile/file"
 local bool = io.isdir(path)
 if bool then
@@ -37,7 +37,7 @@ List all the files within a directory.
 #### Returns
 A table mapping indices to file paths.
 #### Example
-```lua showLineNumbers title="Example Usage"
+```pluto showLineNumbers title="Example Usage"
 for _, filepath in io.listdir(".") do
     print(filepath)
 end
@@ -48,7 +48,7 @@ end
 #### Returns
 A boolean indicating if the path led towards an existing file or directory.
 #### Example
-```lua showLineNumbers title="Example Usage"
+```pluto showLineNumbers title="Example Usage"
 if io.exists("cfg/config.txt") then
     print("Config exists!")
 else
@@ -63,7 +63,7 @@ Copy a file to another file, creating a new file if needed.
 #### Returns
 A boolean indicating if the file was successfully copied.
 #### Example
-```lua showLineNumbers title="Example Usage"
+```pluto showLineNumbers title="Example Usage"
 if io.copyto("./cfg/config.txt", "./backup_cfg/config.txt") then
     print("Successfully created a backup config!")
 else
@@ -80,7 +80,7 @@ Fetch the size of a file in kilobytes.
 #### Returns
 A double.
 #### Example
-```lua showLineNumbers title="Example Usage"
+```pluto showLineNumbers title="Example Usage"
 if io.filesize("cfg/config.txt") < 1.0 then
     print("Config is too small or empty.")
 end
@@ -95,7 +95,7 @@ Create a directory.
 #### Returns
 A boolean indicating if the directory was successfully created.
 #### Example
-```lua showLineNumbers title="Example Usage"
+```pluto showLineNumbers title="Example Usage"
 if io.makedir("./cfg") then
     print("Created cfg directory.")
 else
@@ -109,7 +109,7 @@ Convert a relative path into an absolute one.
 #### Returns
 A string representing the new file path.
 #### Example
-```lua showLineNumbers title="Example Usage"
+```pluto showLineNumbers title="Example Usage"
 --> cfg/config.txt
 io.absolute("cfg/cfg.txt") --> "C:\Users\Desktop\Username\Project\cfg\cfg.txt"
 ```

--- a/docs/Standard Library/OS Functions.md
+++ b/docs/Standard Library/OS Functions.md
@@ -3,7 +3,7 @@ New functions for the `os` library, implemented by Pluto.
 #### Parameters:
 1. The amount of milliseconds to sleep for.
 #### Example
-```lua showLineNumbers title="Basic Usage"
+```pluto showLineNumbers title="Basic Usage"
 os.sleep(1000) --> Pause this thread for 1000ms.
 ```
 ### os.millis

--- a/docs/Standard Library/String Functions.md
+++ b/docs/Standard Library/String Functions.md
@@ -8,7 +8,7 @@ Splits a string by a separator.
 #### Returns
 A table.
 #### Example
-```lua title="Splitting a string by a single character."
+```pluto title="Splitting a string by a single character."
 local s = "hello world, how is everyone doing?"
 local r = string.split(s, " ")
 --[[
@@ -23,7 +23,7 @@ local r = string.split(s, " ")
     }
 --]]
 ```
-```lua title="Splitting a string by a substring."
+```pluto title="Splitting a string by a substring."
 local s = "helloHALLOWORLDworld,HALLOWORLDhowHALLOWORLDisHALLOWORLDeveryoneHALLOWORLDdoing?"
 local r = string.split(s, "HALLOWORLD")
 --[[
@@ -46,7 +46,7 @@ Returns the index of where a substring starts. Begins searching at the left side
 #### Returns
 An integer for the index of the substring, or `nil` if the substring was not found.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 local s = "hello world"
 local r = string.lfind(s, "world") --> 7
 ```
@@ -58,7 +58,7 @@ Returns the index of where a substring starts. Begins searching at the right sid
 #### Returns
 An integer for the index of the substring, or `nil` if the substring was not found.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 local s = "hello world"
 local r = string.rfind(s, "world") --> 7
 ```
@@ -70,7 +70,7 @@ Strips characters from both ends of a string.
 #### Returns
 The new string.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 local s = "{}|hello world{|}"
 local r = string.strip(s, "{}|") --> "hello world"
 ```
@@ -82,7 +82,7 @@ Strips characters from the left side of a string.
 #### Returns
 The new string.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 local s = "<{}|hello world>{|}"
 local r = string.strip(s, "{}|") --> "<hello world>{|}"
 ```
@@ -94,7 +94,7 @@ Strips characters from the right side of a string.
 #### Returns
 The new string.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 local s = "<{}|hello world>{|}"
 local r = string.strip(s, "{}|") --> "<{}|<hello world>"
 ```
@@ -105,7 +105,7 @@ Checks if a string is entirely composed of ASCII characters.
 #### Returns
 A Boolean.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 local s = "HELLOWORLD123"
 local r = string.isascii(r) --> true
 ```
@@ -119,7 +119,7 @@ Checks if a string is entirely composed of lowercase characters.
 #### Returns
 A Boolean.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 local s = "helloworld"
 local r = string.islower(r) --> true
 ```
@@ -133,7 +133,7 @@ Checks if a string is entirely composed of alphabetic characters.
 #### Returns
 A Boolean.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 local s = "HELLOWORLD"
 local r = string.isalpha(r) --> true
 ```
@@ -147,7 +147,7 @@ Checks if a string is entirely composed of uppercase characters.
 #### Returns
 A Boolean.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 local s = "HELLOWORLD"
 local r = string.isupper(r) --> true
 ```
@@ -161,7 +161,7 @@ Checks if a string is entirely composed of alphanumeric characters.
 #### Returns
 A Boolean.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 local s = "HELLOWORLD123"
 local r = string.isalnum(r) --> true
 ```
@@ -176,7 +176,7 @@ Checks if a string contains a substring.
 #### Returns
 A boolean.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 local s = "hello world"
 local r = string.contains(s, "worl") --> true
 ```
@@ -188,7 +188,7 @@ Compares two strings, agnostic of any capitalization.
 #### Returns
 A boolean.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 local s1 = "hello world"
 local s2 = "heLLo WoRlD"
 local r1 = string.casefold(s1, s2) --> true
@@ -202,14 +202,14 @@ Splits a string once, on the first occurance of a separator.
 #### Returns
 Two strings: A substring for all the content before the first occurance of `sep`, and another substring for all the content afterwards.
 #### Example
-```lua title="A Basic Partition"
+```pluto title="A Basic Partition"
 local s = "hello world, what's up?"
 local before, after = string.partition(s, " ")
 
 assert(before == "hello")
 assert(after == "world, what's up?")
 ```
-```lua title="Partioning From The Right"
+```pluto title="Partioning From The Right"
 local s = "hello world, what's up?"
 local before, after = string.partition(s, " ", true)
 
@@ -224,7 +224,7 @@ Checks if a string ends with a suffix.
 #### Returns
 A boolean.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 local s = "hello world"
 local r = string.endswith(s, "world") --> true
 ```
@@ -236,7 +236,7 @@ Checks if a string starts with a prefix.
 #### Returns
 A boolean.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 local s = "hello world"
 local r = string.startswith(s, "hello") --> true
 ```
@@ -248,7 +248,7 @@ Searches the string for the last character that matches any of the characters sp
 #### Returns
 An integer, or `nil` if nothing is matched.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 -- This will find the last occurance of any listed characters.
 local s = "he$$o ?$! world$"
 local r = string.find_last_of(s, "!$") --> 16
@@ -261,7 +261,7 @@ Searches the string for the first character that matches any of the characters s
 #### Returns
 An integer, or `nil` if nothing is matched.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 -- This will find the first occurance of any listed characters.
 local s = "he$$o ?$! world$"
 local r = string.find_first_of(s, "!$") --> 3
@@ -273,7 +273,7 @@ Checks if this string is entirely composed of whitespace characters.
 #### Returns
 A boolean.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 local s = "    \t \v \f     \t\t\t\t"
 local r = string.iswhitespace(s) --> true
 ```
@@ -285,7 +285,7 @@ Searches the string for the last character that does not match any of the charac
 #### Returns
 An integer, or `nil` if nothing is matched.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 -- This will find the last non-occurance of any listed characters.
 local s = "he$$o ?$! world$"
 local r = string.find_last_not_of(s, "!$") --> 15
@@ -298,7 +298,7 @@ Searches the string for the first character that does not match any of the chara
 #### Returns
 An integer, or `nil` if nothing is matched.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 -- This will find the first non-occurance of any listed characters.
 local s = "he$$o ?$! world$"
 local r = string.find_first_not_of(s, "!$") --> 1
@@ -308,14 +308,14 @@ local r = string.find_first_not_of(s, "!$") --> 1
 ### string.upper
 This function now takes a second parameter that specifies which index to capitalize.
 #### Example
-```lua showLineNumbers title="Basic Usage"
+```pluto showLineNumbers title="Basic Usage"
 local s = "hello"
 assert(s:upper(1) == "Hello")
 ```
 ### string.lower
 This function now takes a second parameter that specifies which index to make lowercase.
 #### Example
-```lua showLineNumbers title="Basic Usage"
+```pluto showLineNumbers title="Basic Usage"
 local s = "HELLO"
 assert(s:lower(1) == "hELLO")
 ```

--- a/docs/Standard Library/Table Functions.md
+++ b/docs/Standard Library/Table Functions.md
@@ -6,7 +6,7 @@ Freezes a table to prevent modification.
 #### Returns
 The original table, but frozen.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 local t = table.freeze({...})
 -- `table.freeze(t)` on another line will work fine too.
 t.key = "value" -- Fails.
@@ -18,7 +18,7 @@ Checks if this table is frozen.
 #### Returns
 A boolean.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 local t = {}
 table.freeze(t)
 assert(table.isfrozen(t) == true)
@@ -31,7 +31,7 @@ Checks if this table contains an element.
 #### Returns
 The index if found, otherwise `nil`.
 #### Example
-```lua title="Basic Usage"
+```pluto title="Basic Usage"
 local t = { 1, 2, 3, 4, 5, 6 }
 local r = table.contains(t, 4) --> 4
 ```

--- a/src/theme/pluto.js
+++ b/src/theme/pluto.js
@@ -1,4 +1,4 @@
-Prism.languages.lua = {
+Prism.languages.pluto = {
 	'comment': /^#!.+|--(?:\[(=*)\[[\s\S]*?\]\1\]|.*)/m,
 	'string': {
 		pattern: /(["'])(?:(?!\1)[^\\\r\n]|\\z(?:\r\n|\s)|\\(?:\r\n|[^z]))*\1|\[(=*)\[[\s\S]*?\]\2\]/,

--- a/src/theme/prism-include-languages.js
+++ b/src/theme/prism-include-languages.js
@@ -1,9 +1,4 @@
-import siteConfig from '@generated/docusaurus.config';
 export default function prismIncludeLanguages(PrismObject) {
-  const {
-    themeConfig: {prism},
-  } = siteConfig;
-  const {additionalLanguages} = prism;
   // Prism components work on the Prism instance on the window, while prism-
   // react-renderer uses its own Prism instance. We temporarily mount the
   // instance onto window, import components to enhance it, then remove it to
@@ -12,6 +7,5 @@ export default function prismIncludeLanguages(PrismObject) {
   // long as you don't re-assign it
   globalThis.Prism = PrismObject;
   require("./pluto.js");
-  additionalLanguages.pluto = globalThis.Prism.languages.pluto;
   delete globalThis.Prism;
 }


### PR DESCRIPTION
Plus cleaning up the prism-include-languages.js file. I've tested with local builds that this doesn't break anything.