### PR TITLE
Enable tokenization of dotted function names in search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -18,7 +18,16 @@ const config = {
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/logo.png',
-  plugins: [require.resolve("@easyops-cn/docusaurus-search-local")],
+  plugins: [
+    [
+      require.resolve("@easyops-cn/docusaurus-search-local"),
+      {
+        // Include `zh` to enable a custom tokenizer that splits on symbols
+        // like '.' so queries for `startswith` match `string.startswith`.
+        language: ["en", "zh"],
+      },
+    ],
+  ],
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
## Summary
- configure local search plugin to use tokenizer that splits on punctuation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfa8cd2ab88325a914deb174416a0a